### PR TITLE
refactor: N+1 문제 해결

### DIFF
--- a/src/main/java/org/greedy/ddarahang/api/service/TravelCourseService.java
+++ b/src/main/java/org/greedy/ddarahang/api/service/TravelCourseService.java
@@ -80,7 +80,7 @@ public class TravelCourseService {
         List<TravelCourseDetailResponse> travelCourseDetails = travelCourseDetailRepository.findAllByTravelCourseId(id)
                 .stream().map(TravelCourseDetailResponse::from).toList();
 
-        return TravelCourseResponse.from(travelCourse.getTravelDays(),travelCourse.getVideo(), travelCourseDetails);
+        return TravelCourseResponse.from(travelCourse.getTravelDays(), travelCourse.getVideo(), travelCourseDetails);
     }
 
     private void validateCountryName(String countryName) {

--- a/src/main/java/org/greedy/ddarahang/db/travelCourse/TravelCourseRepository.java
+++ b/src/main/java/org/greedy/ddarahang/db/travelCourse/TravelCourseRepository.java
@@ -1,8 +1,6 @@
 package org.greedy.ddarahang.db.travelCourse;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,26 +9,25 @@ import java.util.Optional;
 @Repository
 public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long> {
 
-    @EntityGraph(attributePaths = {"video"})
-    @NonNull
-    Optional<TravelCourse> findById(@NonNull Long id);
+    @VideoEntityGraph
+    Optional<TravelCourse> findById(Long id);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByCountryName(String countryName);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByRegionName(String regionName);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByCountryNameOrderByVideoUploadDateDesc(String countryName);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByRegionNameOrderByVideoUploadDateDesc(String regionName);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByCountryNameOrderByVideoViewCountDesc(String countryName);
 
-    @EntityGraph(attributePaths = {"video"})
+    @VideoEntityGraph
     List<TravelCourse> findAllByRegionNameOrderByVideoViewCountDesc(String regionName);
 
 }

--- a/src/main/java/org/greedy/ddarahang/db/travelCourse/TravelCourseRepository.java
+++ b/src/main/java/org/greedy/ddarahang/db/travelCourse/TravelCourseRepository.java
@@ -1,23 +1,36 @@
 package org.greedy.ddarahang.db.travelCourse;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long> {
 
+    @EntityGraph(attributePaths = {"video"})
+    @NonNull
+    Optional<TravelCourse> findById(@NonNull Long id);
+
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByCountryName(String countryName);
 
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByRegionName(String regionName);
 
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByCountryNameOrderByVideoUploadDateDesc(String countryName);
 
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByRegionNameOrderByVideoUploadDateDesc(String regionName);
 
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByCountryNameOrderByVideoViewCountDesc(String countryName);
 
+    @EntityGraph(attributePaths = {"video"})
     List<TravelCourse> findAllByRegionNameOrderByVideoViewCountDesc(String regionName);
 
 }

--- a/src/main/java/org/greedy/ddarahang/db/travelCourse/VideoEntityGraph.java
+++ b/src/main/java/org/greedy/ddarahang/db/travelCourse/VideoEntityGraph.java
@@ -1,0 +1,14 @@
+package org.greedy.ddarahang.db.travelCourse;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@EntityGraph(attributePaths = {"video"})
+public @interface VideoEntityGraph {
+}

--- a/src/main/java/org/greedy/ddarahang/db/travelCourseDetail/TravelCourseDetailRepository.java
+++ b/src/main/java/org/greedy/ddarahang/db/travelCourseDetail/TravelCourseDetailRepository.java
@@ -2,11 +2,14 @@ package org.greedy.ddarahang.db.travelCourseDetail;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TravelCourseDetailRepository extends JpaRepository<TravelCourseDetail, Long> {
 
+    @EntityGraph(attributePaths = {"place", "travelCourse"})
     List<TravelCourseDetail> findAllByTravelCourseId(Long travelCourseId);
+
 }

--- a/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
+++ b/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
@@ -258,30 +258,35 @@ class TravelCourseServiceTest extends BaseTest {
         }
     }
 
-    @Test
-    void getTravelCourses_N_plus_1_개선_검증_테스트() {
-        // Given
-        Statistics stats = getStatistics();
+    @Nested
+    class Query_Improvement_Test {
 
-        // When
-        travelCourseService.getTravelCourses("default", "대한민국", "서울");
+        @Test
+        void getTravelCourses_N_plus_1_개선_검증_테스트() {
+            // Given
+            Statistics stats = getStatistics();
 
-        // Then
-        long queryCount = stats.getQueryExecutionCount();
-        assertEquals(1, queryCount);
+            // When
+            travelCourseService.getTravelCourses("default", "대한민국", "서울");
+
+            // Then
+            long queryCount = stats.getQueryExecutionCount();
+            assertEquals(1, queryCount);
+        }
+
+        @Test
+        void getTravelCourseDetail_N_plus_1_개선_검증_테스트() {
+            // Given
+            Statistics stats = getStatistics();
+            Long id = travelCourse.getId();
+
+            // When
+            travelCourseService.getTravelCourseDetail(id);
+
+            // Then
+            long queryCount = stats.getQueryExecutionCount();
+            assertEquals(1, queryCount);
+        }
     }
 
-    @Test
-    void getTravelCourseDetail_N_plus_1_개선_검증_테스트() {
-        // Given
-        Statistics stats = getStatistics();
-        Long id = travelCourse.getId();
-
-        // When
-        travelCourseService.getTravelCourseDetail(id);
-
-        // Then
-        long queryCount = stats.getQueryExecutionCount();
-        assertEquals(1, queryCount);
-    }
 }

--- a/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
+++ b/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
@@ -257,10 +257,7 @@ class TravelCourseServiceTest extends BaseTest {
         Statistics stats = sessionFactory.getStatistics();
         stats.setStatisticsEnabled(true);
 
-        List<TravelCourseListResponse> response = travelCourseService.getTravelCourses("default", "Korea", "");
-
         long queryCount = stats.getQueryExecutionCount();
-        System.out.println("Executed queries: " + queryCount);
 
         assertTrue(queryCount < 2);
     }

--- a/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
+++ b/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class TravelCourseServiceTest extends BaseTest {
@@ -268,7 +268,7 @@ class TravelCourseServiceTest extends BaseTest {
 
         // Then
         long queryCount = stats.getQueryExecutionCount();
-        assertTrue(queryCount < 2);
+        assertEquals(1, queryCount);
     }
 
     @Test
@@ -282,7 +282,6 @@ class TravelCourseServiceTest extends BaseTest {
 
         // Then
         long queryCount = stats.getQueryExecutionCount();
-        assertTrue(queryCount < 2);
+        assertEquals(1, queryCount);
     }
 }
-

--- a/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
+++ b/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
@@ -97,6 +97,14 @@ class TravelCourseServiceTest extends BaseTest {
         travelCourseDetail = travelCourseDetailRepository.save(TravelCourseDetailFixture.getMockTravelCourseDetail(travelCourse, place));
     }
 
+    private Statistics getStatistics() {
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        Statistics stats = sessionFactory.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+        return stats;
+    }
+
     @Nested
     class GetTravelCourseListMethod {
 
@@ -252,13 +260,28 @@ class TravelCourseServiceTest extends BaseTest {
 
     @Test
     void getTravelCourses_N_plus_1_개선_검증_테스트() {
+        // Given
+        Statistics stats = getStatistics();
 
-        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-        Statistics stats = sessionFactory.getStatistics();
-        stats.setStatisticsEnabled(true);
+        // When
+        travelCourseService.getTravelCourses("default", "대한민국", "서울");
 
+        // Then
         long queryCount = stats.getQueryExecutionCount();
+        assertTrue(queryCount < 2);
+    }
 
+    @Test
+    void getTravelCourseDetail_N_plus_1_개선_검증_테스트() {
+        // Given
+        Statistics stats = getStatistics();
+        Long id = travelCourse.getId();
+
+        // When
+        travelCourseService.getTravelCourseDetail(id);
+
+        // Then
+        long queryCount = stats.getQueryExecutionCount();
         assertTrue(queryCount < 2);
     }
 }

--- a/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
+++ b/src/test/java/org/greedy/ddarahang/api/service/TravelCourseServiceTest.java
@@ -1,5 +1,6 @@
 package org.greedy.ddarahang.api.service;
 
+import jakarta.persistence.EntityManagerFactory;
 import org.greedy.ddarahang.api.dto.TravelCourseListResponse;
 import org.greedy.ddarahang.api.dto.TravelCourseResponse;
 import org.greedy.ddarahang.common.exception.InvalidCountryNameException;
@@ -24,6 +25,8 @@ import org.greedy.ddarahang.db.travelCourseDetail.TravelCourseDetail;
 import org.greedy.ddarahang.db.travelCourseDetail.TravelCourseDetailRepository;
 import org.greedy.ddarahang.db.video.Video;
 import org.greedy.ddarahang.db.video.VideoRepository;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,9 +40,13 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class TravelCourseServiceTest extends BaseTest {
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     @Autowired
     private TravelCourseService travelCourseService;
@@ -242,4 +249,20 @@ class TravelCourseServiceTest extends BaseTest {
                     .hasMessage("travel course not found");
         }
     }
+
+    @Test
+    void getTravelCourses_N_plus_1_개선_검증_테스트() {
+
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        Statistics stats = sessionFactory.getStatistics();
+        stats.setStatisticsEnabled(true);
+
+        List<TravelCourseListResponse> response = travelCourseService.getTravelCourses("default", "Korea", "");
+
+        long queryCount = stats.getQueryExecutionCount();
+        System.out.println("Executed queries: " + queryCount);
+
+        assertTrue(queryCount < 2);
+    }
 }
+


### PR DESCRIPTION
<!--
제목: [작업] 회원 가입 기능 구현
-->
getTravelCourses, getTravelCourseDetail 메서드 실행 시 발생하는 N+1 문제 해결

🛰️ Issue Number  
<!--
ex) #12  
-->
#38 

🪐 작업 내용
<!--  
ex)
- 회원 가입 API 개발  
- 이메일 중복 확인 로직 추가  
- 비밀번호 해싱 처리 적용  
- 회원 정보 저장 후 성공/실패 응답 반환
-->
- 추후 페이징 기능과의 연계를 위해 @EntityGraph 를 사용하여 travelCourse, travelCourseDetail 조회 시 각각 video, place & travelCourse를 조회하도록 리팩토링
- 해당 해결 과정의 검증을 위해 해당 서비스 로직 사용 후 반환되는 쿼리문의 수로(1개) 테스트 코드 작성

📚 Reference
<!--  
- https://example.com/signup-api (회원 가입 API 설계서)  
- https://example.com/bcrypt (Spring Security BCryptPasswordEncoder 사용법)
-->  

✅ Check List
<!--issue를 올리기 전 작성자가 검토-->  
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
